### PR TITLE
Fixed the version constraint in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the following in your root composer.json file:
 ```json
 {
     "require": {
-        "incenteev/composer-parameter-handler": "~2.0*"
+        "incenteev/composer-parameter-handler": "~2.0"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
As it is now, it throws an exception:
    [UnexpectedValueException]  
        Could not parse version constraint ~2.0_: Invalid version string "~2.0_" 
