### PR TITLE
Fixes Issue #21 Adds Support for Multiple Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ Add the following in your root composer.json file:
     },
     "extra": {
         "incenteev-parameters": {
-            "file": {
-                "parameters": "app/config/parameters.yml"
-            }
+            "file": "app/config/parameters.yml"
         }
     }
 }
@@ -42,10 +40,8 @@ file, suffixed by ``.dist``. This can be changed in the configuration:
 {
     "extra": {
         "incenteev-parameters": {
-            "file": {
-                "parameters": "app/config/parameters.yml",
-                "parameters-dist": "some/other/folder/to/other/parameters/file/parameters.yml.dist"
-            }
+            "file": "app/config/parameters.yml",
+            "dist-file": "some/other/folder/to/other/parameters/file/parameters.yml.dist"
         }
     }
 }
@@ -72,7 +68,7 @@ If you need to keep outdated params you can use `keep-outdated` param in the con
 
 ### Multiple Files
 
-To use multiple files files the file map accepts named files. Dist files should be the designated by
+To use multiple files the file map accepts named files. Dist files should be the designated by
 affixing ``-dist`` to the name. The script handler will organize these and loop over them to process each
 file appropriately.  
 


### PR DESCRIPTION
Adds support for multiple files. ~~However, it does alter the API - might be better suited for a 3.0 release.~~ 

Description:
File can be a string for a single file or a hashmap for multiple files.
The hashmap will have named files and named -dist files. 
Then the array/map is processed for each file solving the  problem of multiple file support.

EDIT: No longer breaks API/BC
