### PR TITLE
Fixes #20 - Top-level keys on the yml files other than 'parameters' were not being maintained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 2.1.0 (2013-06-26)
+## 2.1.0
 
-* Fixes #20 - Top-level keys on the yml files other than 'parameters' were not being maintained
+* Fixes #20 - Preserve other top-level keys than ``parameters`` in the file
 
 ## 2.0.0 (2013-04-06)
 

--- a/ScriptHandler.php
+++ b/ScriptHandler.php
@@ -77,11 +77,10 @@ class ScriptHandler
 
         $actualParams = self::getParams($io, $expectedParams, $actualParams);
 
-        // Keep existing top-level keys and override parameters with the new values
-        $newValues = $actualValues;
-        $newValues['parameters'] = $actualParams;
+        // Preserve other top-level keys than `parameters` in the file
+        $actualValues['parameters'] = $actualParams;
 
-        file_put_contents($realFile, "# This file is auto-generated during the composer install\n" . Yaml::dump($newValues));
+        file_put_contents($realFile, "# This file is auto-generated during the composer install\n" . Yaml::dump($actualValues));
     }
 
     private static function getEnvValues(array $envMap)


### PR DESCRIPTION
- Fixes #20 - Top-level keys on the yml files other than 'parameters' were not being maintained
- Added CONTRIBUTORS.md
