### PR TITLE
Improve human readability when you use array parameters

### DIFF
--- a/ScriptHandler.php
+++ b/ScriptHandler.php
@@ -83,7 +83,7 @@ class ScriptHandler
 
         $actualParams = self::getParams($io, $expectedParams, $actualParams);
 
-        file_put_contents($realFile, "# This file is auto-generated during the composer install\n" . Yaml::dump(array($parameterKey => $actualParams)));
+        file_put_contents($realFile, "# This file is auto-generated during the composer install\n" . Yaml::dump(array($parameterKey => $actualParams), 99));
     }
 
     private static function getEnvValues(array $envMap)


### PR DESCRIPTION
Set level where YAML switch to inline to 99 in order to improve human readability when you use array parameters as is explained here http://symfony.com/doc/current/components/dependency_injection/parameters.html#array-parameters.
