### PR TITLE
Add possibility of merge missing nested array values under the top-level...

### DIFF
--- a/ScriptHandler.php
+++ b/ScriptHandler.php
@@ -167,16 +167,15 @@ class ScriptHandler
     {
         // Simply use the expectedParams value as default for the missing params.
         if (!$io->isInteractive()) {
-            return array_replace($expectedParams, $actualParams);
+            return array_replace_recursive($expectedParams, $actualParams);
         }
 
         $isStarted = false;
 
-        foreach ($expectedParams as $key => $message) {
-            if (array_key_exists($key, $actualParams)) {
-                continue;
-            }
+        $diffParams = self::arrayDiffKeyRecursive($expectedParams, $actualParams);
 
+        foreach ($diffParams as $key => $message)
+        {
             if (!$isStarted) {
                 $isStarted = true;
                 $io->write('<comment>Some parameters are missing. Please provide them.</comment>');
@@ -185,9 +184,42 @@ class ScriptHandler
             $default = Inline::dump($message);
             $value = $io->ask(sprintf('<question>%s</question> (<comment>%s</comment>): ', $key, $default), $default);
 
-            $actualParams[$key] = Inline::parse($value);
+            if (array_key_exists($key, $actualParams))
+            {
+                $actualParams[$key] = array_merge($actualParams[$key], Inline::parse($value));
+            }
+            else
+            {
+                $actualParams[$key] = Inline::parse($value);
+            }
         }
 
         return $actualParams;
+    }
+
+    /**
+     * Return recursive diff based on keys
+     * @param  array  $arr1 [description]
+     * @param  array  $arr2 [description]
+     * @return [type]       [description]
+     */
+    private static function arrayDiffKeyRecursive (array $arr1, array $arr2) 
+    {
+        $diff = array_diff_key($arr1, $arr2);
+        $intersect = array_intersect_key($arr1, $arr2);
+
+        foreach ($intersect as $k => $v) 
+        {
+            if (is_array($arr1[$k]) && is_array($arr2[$k])) 
+            {
+                $d = self::arrayDiffKeyRecursive($arr1[$k], $arr2[$k]);
+
+                if ($d) 
+                {
+                    $diff[$k] = $d;
+                }
+            }
+        }
+        return $diff;
     }
 }

--- a/Tests/fixtures/testcases/extra_array_keys/dist.yml
+++ b/Tests/fixtures/testcases/extra_array_keys/dist.yml
@@ -1,0 +1,12 @@
+parameters:
+    foo: bar
+    bare:
+        foo2: existing_foo2
+        foo3: existing_foo3
+        foo4: existing_foo4
+        foo5:
+            bare2:
+                - bloup
+                - glop
+
+extra_key: a new extra key

--- a/Tests/fixtures/testcases/extra_array_keys/existing.yml
+++ b/Tests/fixtures/testcases/extra_array_keys/existing.yml
@@ -1,0 +1,7 @@
+# This file is auto-generated during the composer install
+parameters:
+    foo: existing_foo
+    bare:
+        foo1: existing_foo1
+        foo3: existing_foo3
+another_key: foo

--- a/Tests/fixtures/testcases/extra_array_keys/expected.yml
+++ b/Tests/fixtures/testcases/extra_array_keys/expected.yml
@@ -1,0 +1,14 @@
+# This file is auto-generated during the composer install
+parameters:
+    foo: existing_foo
+    bare:
+        foo2: existing_foo2
+        foo3: existing_foo3
+        foo4: existing_foo4
+        foo5:
+            bare2:
+                - bloup
+                - glop
+        foo1: existing_foo1
+another_key: foo
+extra_key: 'a new extra key'

--- a/Tests/fixtures/testcases/extra_array_keys/setup.yml
+++ b/Tests/fixtures/testcases/extra_array_keys/setup.yml
@@ -1,0 +1,1 @@
+title: Extra deep array keys and preserve existing values


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Tests pass: yes

With this, we can now have new multi dimensional arrays in the dist file under the top-level key parameter be merged in the generated parameter file.

The prompt is still waiting for a full YAML definition of the missing key.
