### PR TITLE
Added a config to directly use top level keys as parameters

### DIFF
--- a/Tests/fixtures/testcases/no_parameter_key/dist.yml
+++ b/Tests/fixtures/testcases/no_parameter_key/dist.yml
@@ -1,0 +1,2 @@
+foo: bar
+boolean: false

--- a/Tests/fixtures/testcases/no_parameter_key/existing.yml
+++ b/Tests/fixtures/testcases/no_parameter_key/existing.yml
@@ -1,0 +1,2 @@
+# This file is auto-generated during the composer install
+foo: existing_foo

--- a/Tests/fixtures/testcases/no_parameter_key/expected.yml
+++ b/Tests/fixtures/testcases/no_parameter_key/expected.yml
@@ -1,0 +1,3 @@
+# This file is auto-generated during the composer install
+foo: existing_foo
+boolean: false

--- a/Tests/fixtures/testcases/no_parameter_key/setup.yml
+++ b/Tests/fixtures/testcases/no_parameter_key/setup.yml
@@ -1,0 +1,4 @@
+title: "When 'no-parameter-key' config is set to true, top level keys are used as parameters"
+
+config:
+    no-parameter-key: true


### PR DESCRIPTION
My usecase is the following: Some of apps I'm working on are using YAML file to store config without having a single top-level keys (like `parameters` or `config`). And I would be happy to be able to use this handy scripts (without the need to change the way we are structuring our config file).

I don't know, maybe this is a bit too far away of the original idea of this library...
