### PR TITLE
Recurse through params

### DIFF
--- a/Processor.php
+++ b/Processor.php
@@ -151,7 +151,10 @@ class Processor
         $ask = function($defaults, $params) use (&$ask) {
             foreach ($defaults as $key => $default) {
                 if (is_array($default)) {
-                    $params[$key] = $ask($default, $params);
+                    if (!isset ($params[$key])) {
+                        $params[$key] = array();
+                    }
+                    $params[$key] = $ask($default, $params[$key]);
                 }
                 else {
                     $value = $this->io->ask(sprintf('<question>%s</question> (<comment>%s</comment>): ', $key, $default), $default);


### PR DESCRIPTION
Allows multi-level config params with interactive flow. The only other way to walk a user through something with more than one level would be to give them a couple big ugly hashes to fill out at the prompt.

I certainly would agree that applications should expose a one-level configuration, but this just isn't what always happens.

Please let me know if there's anything else I need to change.
