### PR TITLE
Add a more detailed exception message when a top-level key is missing.

### DIFF
--- a/Processor.php
+++ b/Processor.php
@@ -33,7 +33,7 @@ class Processor
         // Find the expected params
         $expectedValues = $yamlParser->parse(file_get_contents($config['dist-file']));
         if (!isset($expectedValues[$parameterKey])) {
-            throw new \InvalidArgumentException('The dist file seems invalid.');
+            throw new \InvalidArgumentException(sprintf('The top-level key %s is missing.', $parameterKey));
         }
         $expectedParams = (array) $expectedValues[$parameterKey];
 

--- a/Tests/ProcessorTest.php
+++ b/Tests/ProcessorTest.php
@@ -74,7 +74,7 @@ class ProcessorTest extends ProphecyTestCase
                 array(
                     'file' => 'fixtures/invalid/missing_top_level.yml',
                 ),
-                'The dist file seems invalid.',
+                'The top-level key parameters is missing.',
             ),
             'invalid values in the existing file' => array(
                 array(


### PR DESCRIPTION
I have installed this useful tool but I missed to set the top-level key. The exception message was "The dist file seems invalid" and I searched an issue with my yaml synthax. A more detailed message may be appreciable.
