### PR TITLE
Add setting to throw exception in non-interactive mode if some params are missing

### DIFF
--- a/Processor.php
+++ b/Processor.php
@@ -104,7 +104,7 @@ class Processor
         // Add the params coming from the environment values
         $actualParams = array_replace($actualParams, $this->getEnvValues($envMap));
 
-        return $this->getParams($expectedParams, $actualParams);
+        return $this->getParams($config, $expectedParams, $actualParams);
     }
 
     private function getEnvValues(array $envMap)
@@ -137,10 +137,14 @@ class Processor
         return $actualParams;
     }
 
-    private function getParams(array $expectedParams, array $actualParams)
+    private function getParams(array $config, array $expectedParams, array $actualParams)
     {
-        // Simply use the expectedParams value as default for the missing params.
         if (!$this->io->isInteractive()) {
+            if (!empty($config['exception-if-missing']) && $missingParams = array_diff_key($expectedParams, $actualParams)) {
+                // Throw exception in non-interactive mode if some params are missing
+                throw new \RuntimeException(sprintf("Some parameters are missing: %s. Please fill them.", implode(", ", array_keys($missingParams))));
+            }
+            // Simply use the expectedParams value as default for the missing params
             return array_replace($expectedParams, $actualParams);
         }
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ will be used for missing parameters.
 your parameters.yml file so handle with care. If you want to give format
 and comments to your parameter's file you should do it on your dist version.
 
+### Throwing exception if some parameters are missing in non-interactive mode
+
+You can also force the script handler to throw an exception when some parameters
+are missing in non-interactive mode by using `exception-if-missing` param in the configuration:
+
+```json
+{
+    "extra": {
+        "incenteev-parameters": {
+            "exception-if-missing": true
+        }
+    }
+}
+```
+
 ### Keeping outdated parameters
 
 Warning: This script removes outdated params from ``parameters.yml`` which are not in ``parameters.yml.dist``

--- a/Tests/ProcessorTest.php
+++ b/Tests/ProcessorTest.php
@@ -115,7 +115,9 @@ class ProcessorTest extends ProphecyTestCase
 
         $this->processor->processFile($testCase['config']);
 
-        $this->assertFileEquals($dataDir.'/expected.yml', $workingDir.'/'.$testCase['config']['file'], $testCase['title']);
+        if (file_exists($expected = $dataDir.'/expected.yml')) {
+            $this->assertFileEquals($expected, $workingDir.'/'.$testCase['config']['file'], $testCase['title']);
+        }
     }
 
     private function initializeTestCase(array $testCase, $dataDir, $workingDir)
@@ -147,6 +149,11 @@ class ProcessorTest extends ProphecyTestCase
         $this->io->isInteractive()->willReturn($testCase['interactive']);
 
         if (!$testCase['interactive']) {
+            if (!empty($testCase['config']['exception-if-missing']) && !empty($testCase['missing_params'])) {
+                    $this->setExpectedException(
+                        'RuntimeException',
+                        "Some parameters are missing: ".implode(", ", $testCase['missing_params']).". Please fill them.");
+            }
             return;
         }
 

--- a/Tests/fixtures/testcases/exception_if_missing/dist.yml
+++ b/Tests/fixtures/testcases/exception_if_missing/dist.yml
@@ -1,0 +1,4 @@
+parameters:
+    foo: bar
+    another: test
+    boolean: true

--- a/Tests/fixtures/testcases/exception_if_missing/existing.yml
+++ b/Tests/fixtures/testcases/exception_if_missing/existing.yml
@@ -1,0 +1,3 @@
+# This file is auto-generated during the composer install
+parameters:
+    foo: existing_foo

--- a/Tests/fixtures/testcases/exception_if_missing/setup.yml
+++ b/Tests/fixtures/testcases/exception_if_missing/setup.yml
@@ -1,0 +1,6 @@
+title: Missing keys involves exception thrown in non-interaction mode
+
+config:
+    exception-if-missing: true
+
+missing_params: ['another', 'boolean']

--- a/Tests/fixtures/testcases/no_exception_if_no_missing/dist.yml
+++ b/Tests/fixtures/testcases/no_exception_if_no_missing/dist.yml
@@ -1,0 +1,4 @@
+parameters:
+    foo: bar
+    another: test
+    boolean: true

--- a/Tests/fixtures/testcases/no_exception_if_no_missing/existing.yml
+++ b/Tests/fixtures/testcases/no_exception_if_no_missing/existing.yml
@@ -1,0 +1,5 @@
+# This file is auto-generated during the composer install
+parameters:
+    foo: existing_foo
+    another: existing_test
+    boolean: false

--- a/Tests/fixtures/testcases/no_exception_if_no_missing/expected.yml
+++ b/Tests/fixtures/testcases/no_exception_if_no_missing/expected.yml
@@ -1,0 +1,5 @@
+# This file is auto-generated during the composer install
+parameters:
+    foo: existing_foo
+    another: existing_test
+    boolean: false

--- a/Tests/fixtures/testcases/no_exception_if_no_missing/setup.yml
+++ b/Tests/fixtures/testcases/no_exception_if_no_missing/setup.yml
@@ -1,0 +1,4 @@
+title: No exception is thrown in non-interaction mode if all the required params are provided
+
+config:
+    exception-if-missing: true


### PR DESCRIPTION
This PR covers #63 and provides new `exception-if-missing` configuration option. 

By default the behavior of script handler is the same as current. But when `exception-if-missing` option is set to `true` ParameterHandler will throw an exception when some parameters are missing. This is very useful during build/deploy process (executed for example on build/ci servers) when it is needed only to validate `parameters.yml` file before installing the application and abort the process when something went wrong, but not to change it's original content in any way.

This behavior affects only non-interactive mode.
