### PR TITLE
Added setter for dot notation when working with env vars

### DIFF
--- a/Processor.php
+++ b/Processor.php
@@ -112,12 +112,32 @@ class Processor
         $params = array();
         foreach ($envMap as $param => $env) {
             $value = getenv($env);
-            if ($value) {
-                $params[$param] = Inline::parse($value);
+
+            if (!$value) {
+                continue;
             }
+
+            if (false !== strpos($param, '.')) {
+                $this->setValueByPath($params, $param, Inline::parse($value));
+
+                continue;
+            }
+
+            $params[$param] = Inline::parse($value);
         }
 
         return $params;
+    }
+
+    private function setValueByPath(array &$array, $path, $value)
+    {
+        $index = &$array;
+
+        foreach(explode('.', $path) as $level) {
+            $index = &$index[$level];
+        }
+
+        $index = $value;
     }
 
     private function processRenamedValues(array $renameMap, array $actualParams)

--- a/Tests/fixtures/testcases/interaction_with_environment/dist.yml
+++ b/Tests/fixtures/testcases/interaction_with_environment/dist.yml
@@ -2,3 +2,6 @@ parameters:
     boolean: false
     another: test
     nested: nested
+    more:
+        nested:
+            param: foobar

--- a/Tests/fixtures/testcases/interaction_with_environment/expected.yml
+++ b/Tests/fixtures/testcases/interaction_with_environment/expected.yml
@@ -7,4 +7,7 @@ parameters:
             - env
             - test
             - null
+    more:
+        nested:
+            param: barfoo
     another: null

--- a/Tests/fixtures/testcases/interaction_with_environment/setup.yml
+++ b/Tests/fixtures/testcases/interaction_with_environment/setup.yml
@@ -4,10 +4,12 @@ config:
     env-map:
         boolean: IC_TEST_BOOL
         nested: IC_TEST_NESTED
+        more.nested.param: IC_TEST_MORE
 
 environment:
     IC_TEST_BOOL: 'true'
     IC_TEST_NESTED: '{foo: env_foo, bar: [env, test, null]}'
+    IC_TEST_MORE: 'barfoo'
 
 interactive: true
 


### PR DESCRIPTION
Mapping environment variables is a huge boost in deployment productivity. But when you're dealing with nested parameters, it's a huge pain to map variables properly, since you have to store a JSON object inside the environment variable. This PR ads a new feature that allows you to use dot notation to reach nested values. 

Example:

```json
"env-map": {
    "database.default.dbname": "DEFAULT_DB_NAME",
}
```