### PR TITLE
Recursively replace parameter file %tags%

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,29 @@ As environment variables can only be strings, they are also parsed as inline
 Yaml values to allows specifying ``null``, ``false``, ``true`` or numbers
 easily.
 
+### Using environment variables to replace tags
+
+Environment variables can also be used to replace %tags% in your parameter 
+files. By providing a map between environment variables and the tags, the parameters
+will be searched for occurrences of these tags.
+
+```json
+{
+    "extra": {
+        "incenteev-parameters": {
+            "env-tag-map": {
+                "foo2": "FOO2",
+                "foo3": "FOO3"
+            }
+        }
+    }
+}
+```
+
+If an environment variable is set, its value will always replace any %foo2% and %foo3%
+tags in the parameters file. The parameters are scanned recursively and tags can be
+ part of a string and/or combined with other tags. 
+
 ### Renaming parameters
 
 If you are renaming a parameter, the new key will be set according to the usual

--- a/Tests/fixtures/testcases/interaction_with_environment/dist.yml
+++ b/Tests/fixtures/testcases/interaction_with_environment/dist.yml
@@ -2,3 +2,9 @@ parameters:
     boolean: false
     another: test
     nested: nested
+    tags:
+        foo1: bar1
+        foo2: %foo2%
+        foo3:
+            foo4: %foo2%
+            foo5: '%foo2% - %foo4%'

--- a/Tests/fixtures/testcases/interaction_with_environment/expected.yml
+++ b/Tests/fixtures/testcases/interaction_with_environment/expected.yml
@@ -8,3 +8,9 @@ parameters:
             - test
             - null
     another: null
+    tags:
+        foo1: bar1
+        foo2: bar2
+        foo3:
+            foo4: bar2
+            foo5: 'bar2 - bar3'

--- a/Tests/fixtures/testcases/interaction_with_environment/setup.yml
+++ b/Tests/fixtures/testcases/interaction_with_environment/setup.yml
@@ -4,10 +4,16 @@ config:
     env-map:
         boolean: IC_TEST_BOOL
         nested: IC_TEST_NESTED
+    env-tag-map:
+        foo2: IC_TEST_FOO2
+        foo3: IC_TEST_FOO3
+        foo4: IC_TEST_FOO4_NOT_SET
 
 environment:
     IC_TEST_BOOL: 'true'
     IC_TEST_NESTED: '{foo: env_foo, bar: [env, test, null]}'
+    IC_TEST_FOO2: bar2
+    IC_TEST_FOO3: bar3
 
 interactive: true
 
@@ -15,3 +21,6 @@ requested_params:
     another:
         default: test
         input: 'null'
+    tags:
+        default: "{ foo1: bar1, foo2: bar2, foo3: { foo4: bar2, foo5: 'bar2 - %foo4%' } }"
+        input: "{ foo1: bar1, foo2: bar2, foo3: { foo4: bar2, foo5: 'bar2 - bar3' } }"


### PR DESCRIPTION
|  Q             | A    |
| -------------- | ---- |
| Bug fix ?      | No   |
| New feature ?  | Yes  |
| BC breaks ?    | No   |
| Deprecations ? | No   |
| Tests pass ?   | Yes  |

The lack of support for nested parameters caught us by surprise, therefor we came up with the
 following addition. This change allows users to replace %tags% anywhere in the parameters file
 with environment variables.
 
Tags are only replaced if they exist and are never added to the parameters. We found this an
elegant solution, as the real parameters file will follow the structure of the dist file more
 closely.

Given the following parameters file:
```yaml
parameters:
    foo1: %foo1%
    foo2: %foo2%
    foo3:
        foo4: %foo1%
        foo5: '%foo1% - %foo2%'
```

And composer.json configuration:
```json
{
    "extra": {
        "incenteev-parameters": {
            "env-tag-map": {
                "foo1": "FOO1",
                "foo2": "FOO2"
            }
        }
    }
}
```

And environment variables FOO1 and FOO2 are set to 'bar1' and 'bar2', the following
 replacement will occur:
 
 ```yaml
 parameters:
     foo1: bar1
     foo2: bar2
     foo3:
         foo4: bar1
         foo5: 'bar1 - bar2'
 ```