### PR TITLE
updated deprecated use of Yaml::parse

### DIFF
--- a/Tests/ProcessorTest.php
+++ b/Tests/ProcessorTest.php
@@ -102,7 +102,7 @@ class ProcessorTest extends ProphecyTestCase
                 'environment' => array(),
                 'interactive' => false,
             ),
-            (array) Yaml::parse($dataDir.'/setup.yml')
+            (array) Yaml::parse(file_get_contents($dataDir.'/setup.yml'))
         );
 
         $workingDir = sys_get_temp_dir() . '/incenteev_parameter_handler';


### PR DESCRIPTION
Per [Symfony documentation] (http://symfony.com/doc/current/components/yaml/introduction.html): "Passing a filename is deprecated in Symfony 2.2, and will be removed in Symfony 3.0."

Updated use:
`Yaml::parse(file_get_contents('/path/to/file.yml'));`
