### PR TITLE
Automatically assume default value for some selected parameters under interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,25 @@ If the old parameter is no longer present (maybe because it has been renamed and
 removed already), no parameters are overwritten. You don't need to remove obsolete
 parameters from the rename map once they have been renamed.
 
+### Automatic assumption of parameters default value on interaction mode
+
+If you have several parameters that hardly change their values you can identify them so that
+ the default value is automatically assumed even when using the interactive prompt.
+This is achieved by providing a list (array) of parameters that will assume this behaviour
+ under the `assume-default-for-keys` param in the configuration:
+```json
+{
+    "extra": {
+        "incenteev-parameters": {
+            "assume-default-for-keys": [
+                "my_first_param",
+                "my_second_param"
+            ]
+        }
+    }
+}
+```
+
 ### Managing multiple ignored files
 
 The parameter handler can manage multiple ignored files. To use this feature,

--- a/Tests/fixtures/testcases/interaction_assume_default_keys/dist.yml
+++ b/Tests/fixtures/testcases/interaction_assume_default_keys/dist.yml
@@ -1,0 +1,4 @@
+parameters:
+    foo: bar
+    boolean: false
+    another: ~

--- a/Tests/fixtures/testcases/interaction_assume_default_keys/expected.yml
+++ b/Tests/fixtures/testcases/interaction_assume_default_keys/expected.yml
@@ -1,0 +1,5 @@
+# This file is auto-generated during the composer install
+parameters:
+    foo: bar
+    boolean: true
+    another: test_input

--- a/Tests/fixtures/testcases/interaction_assume_default_keys/setup.yml
+++ b/Tests/fixtures/testcases/interaction_assume_default_keys/setup.yml
@@ -1,0 +1,14 @@
+title: Existing values are not asked interactively again
+
+interactive: true
+
+config:
+    assume-default-for-keys: [foo]
+
+requested_params:
+    boolean:
+        default: 'false'
+        input: 'true'
+    another:
+        default: 'null'
+        input: 'test_input'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Tests pass?   | Yes
| Fixed tickets | #83 

This allows the parameter-handler to ignore some parameters on interactive asking and just take the default from the dist file.

The result of this will be something like:
![assume_default_value_on_interactive](https://cloud.githubusercontent.com/assets/2746590/11695034/106e55ec-9ea5-11e5-9cad-d7aca1b4fb86.png)

Comments regarding the new configuration name (or any other stuff such as tests) are welcome. :)

Regards,

------------
> This pull request was made during the Open Source Day @ [beubi](http://beubi.com) :green_heart: