### PR TITLE
Support whitelist of parameters in interactive mode

### DIFF
--- a/Processor.php
+++ b/Processor.php
@@ -104,7 +104,9 @@ class Processor
         // Add the params coming from the environment values
         $actualParams = array_replace($actualParams, $this->getEnvValues($envMap));
 
-        return $this->getParams($expectedParams, $actualParams);
+        $interactiveParams = empty($config['interactive-keys']) ? array() : $config['interactive-keys'];
+
+        return $this->getParams($expectedParams, $actualParams, $interactiveParams);
     }
 
     private function getEnvValues(array $envMap)
@@ -137,7 +139,7 @@ class Processor
         return $actualParams;
     }
 
-    private function getParams(array $expectedParams, array $actualParams)
+    private function getParams(array $expectedParams, array $actualParams, array $interactiveParams)
     {
         // Simply use the expectedParams value as default for the missing params.
         if (!$this->io->isInteractive()) {
@@ -145,9 +147,16 @@ class Processor
         }
 
         $isStarted = false;
+        $hasWhitelist = count($interactiveParams) > 0;
 
         foreach ($expectedParams as $key => $message) {
             if (array_key_exists($key, $actualParams)) {
+                continue;
+            }
+
+            if ($hasWhitelist && !in_array($key, $interactiveParams)) {
+                $actualParams[$key] = $message;
+
                 continue;
             }
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ As environment variables can only be strings, they are also parsed as inline
 Yaml values to allows specifying ``null``, ``false``, ``true`` or numbers
 easily.
 
+### Filtering interactive parameters
+
+By default, the interactive prompt asks for every parameter missing in the
+parameters file. If you want to restrict that behaviour to a particular set
+of parameters, and let the handler use the default values otherwise, you can
+do so by specifying a whitelist in the `interactive-keys` property:
+
+```json
+{
+    "extra": {
+        "incenteev-parameters": {
+            "interactive-keys": [
+                "param_1",
+                "param_3",
+                "param_8"
+            ]
+        }
+    }
+}
+```
+
 ### Renaming parameters
 
 If you are renaming a parameter, the new key will be set according to the usual

--- a/Tests/fixtures/testcases/interaction_filtered_keys/dist.yml
+++ b/Tests/fixtures/testcases/interaction_filtered_keys/dist.yml
@@ -1,0 +1,10 @@
+parameters:
+    boolean: false
+    another: test
+    nested:
+        foo: bar
+        bar:
+            - foo
+            - test
+            - null
+

--- a/Tests/fixtures/testcases/interaction_filtered_keys/expected.yml
+++ b/Tests/fixtures/testcases/interaction_filtered_keys/expected.yml
@@ -1,0 +1,10 @@
+# This file is auto-generated during the composer install
+parameters:
+    boolean: true
+    another: test
+    nested:
+        foo: bar
+        bar:
+            - foo
+            - test
+            - null

--- a/Tests/fixtures/testcases/interaction_filtered_keys/setup.yml
+++ b/Tests/fixtures/testcases/interaction_filtered_keys/setup.yml
@@ -1,0 +1,16 @@
+title: Non-interactive keys are not asked interactively
+
+interactive: true
+
+config:
+    interactive-keys:
+        - boolean
+        - another
+
+requested_params:
+    boolean:
+        default: 'false'
+        input: 'true'
+    another:
+        default: test
+        input: test


### PR DESCRIPTION
This PR adds a feature very similar to the one discussed and proposed in #83 and #93, but takes a whitelist approach instead. The idea is to allow to specify which parameters are asked in interactive mode, and let the handler use the default/dist values otherwise:

```json
{
    "extra": {
        "incenteev-parameters": {
            "interactive-keys": [
                "param_1",
                "param_3",
                "param_8"
            ]
        }
    }
}
```