### PR TITLE
add support <env>.<dist-file>

### DIFF
--- a/Tests/ProcessorTest.php
+++ b/Tests/ProcessorTest.php
@@ -111,6 +111,11 @@ class ProcessorTest extends ProphecyTestCase
         $message = sprintf('<info>%s the "%s" file</info>', $exists ? 'Updating' : 'Creating', $testCase['config']['file']);
         $this->io->write($message)->shouldBeCalled();
 
+        if (!empty($testCase['config']['env'])) {
+            $message = sprintf('<info>Current environment %s=%s</info>', $testCase['config']['env'], getenv($testCase['config']['env']));
+            $this->io->write($message)->shouldBeCalled();
+        }
+
         $this->setInteractionExpectations($testCase);
 
         $this->processor->processFile($testCase['config']);
@@ -135,7 +140,12 @@ class ProcessorTest extends ProphecyTestCase
         foreach ($testCase['environment'] as $var => $value) {
             $this->environmentBackup[$var] = getenv($var);
             putenv($var.'='.$value);
-        };
+        }
+
+        if (!empty($testCase['config']['env'])) {
+            $env = getenv($testCase['config']['env']);
+            $fs->copy($dataDir.'/'.$env.'.dist.yml', $workingDir.'/'.$env.'.'.$testCase['dist-file']);
+        }
 
         chdir($workingDir);
 

--- a/Tests/fixtures/testcases/environment/dist.yml
+++ b/Tests/fixtures/testcases/environment/dist.yml
@@ -1,0 +1,3 @@
+parameters:
+    foo: bar
+    bar: baz

--- a/Tests/fixtures/testcases/environment/existing.yml
+++ b/Tests/fixtures/testcases/environment/existing.yml
@@ -1,0 +1,3 @@
+# This file is auto-generated during the composer install
+parameters:
+    foo: existing_foo

--- a/Tests/fixtures/testcases/environment/expected.yml
+++ b/Tests/fixtures/testcases/environment/expected.yml
@@ -1,0 +1,4 @@
+# This file is auto-generated during the composer install
+parameters:
+    foo: existing_foo
+    bar: test_bar

--- a/Tests/fixtures/testcases/environment/setup.yml
+++ b/Tests/fixtures/testcases/environment/setup.yml
@@ -1,0 +1,7 @@
+title: Environment specific file will applied
+
+config:
+  env: APPLICATION_ENV
+
+environment:
+  APPLICATION_ENV: test

--- a/Tests/fixtures/testcases/environment/test.dist.yml
+++ b/Tests/fixtures/testcases/environment/test.dist.yml
@@ -1,0 +1,3 @@
+parameters:
+    foo: test_foo
+    bar: test_bar


### PR DESCRIPTION
| Q | A |
|---|---|
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

We have a large PHP project with different environments (stage [pre-prod], dev, test, etc). Each of them has **a lot of individual** parameters.

The solution is as follows:
- create environment specific parameter files
 - parameters.yml - basis
 - test.parameters.yml
 - stage.parameters.yml
- run `APP_ENV=stage composer install`, where name of environment variable (in this example is APP_ENV) is customizable