### PR TITLE
Added support of empty strings

### DIFF
--- a/Processor.php
+++ b/Processor.php
@@ -112,7 +112,7 @@ class Processor
         $params = array();
         foreach ($envMap as $param => $env) {
             $value = getenv($env);
-            if ($value) {
+            if ($value !== false) {
                 $params[$param] = Inline::parse($value);
             }
         }

--- a/Tests/fixtures/testcases/non_existent_with_environment/dist.yml
+++ b/Tests/fixtures/testcases/non_existent_with_environment/dist.yml
@@ -2,6 +2,7 @@ parameters:
     foo: bar
     boolean: false
     another: ~
+    empty: nonempty
     nested:
         foo: bar
         bar: baz

--- a/Tests/fixtures/testcases/non_existent_with_environment/expected.yml
+++ b/Tests/fixtures/testcases/non_existent_with_environment/expected.yml
@@ -3,6 +3,7 @@ parameters:
     foo: foobar
     boolean: true
     another: null
+    empty: ''
     nested:
         foo: env_foo
         bar:

--- a/Tests/fixtures/testcases/non_existent_with_environment/setup.yml
+++ b/Tests/fixtures/testcases/non_existent_with_environment/setup.yml
@@ -6,8 +6,10 @@ config:
         foo: IC_TEST_FOO
         nested: IC_TEST_NESTED
         another: IC_TEST_NOT_SET
+        empty: IC_TEST_EMPTY
 
 environment:
     IC_TEST_BOOL: 'true'
     IC_TEST_FOO: 'foobar'
     IC_TEST_NESTED: '{foo: env_foo, bar: [env, test, null]}'
+    IC_TEST_EMPTY: ''


### PR DESCRIPTION
* Added support of empty environment strings
* Added a test case

Note that empty environment strings are not the same as non-set environment strings (`~`):

```
$ MEM_DATA= php -a
Interactive shell

php > var_dump(getenv('MEM_DATA'));
string(0) ""
php > ^D

$ php -a
Interactive shell

php > var_dump(getenv('MEM_DATA'));
bool(false)
```