### PR TITLE
Add an option to disable parameter handler in composer production mode

### DIFF
--- a/Processor.php
+++ b/Processor.php
@@ -16,12 +16,17 @@ class Processor
         $this->io = $io;
     }
 
-    public function processFile(array $config)
+    public function processFile(array $config, $devMode = true)
     {
         $config = $this->processConfig($config);
 
         $realFile = $config['file'];
         $parameterKey = $config['parameter-key'];
+
+        if ($devMode !== true && !empty($config['dev-only']) && true === $config['dev-only']) {
+            $this->io->write(sprintf('<info>Skipping the "%s" file</info>', $realFile));
+            return;
+        }
 
         $exists = is_file($realFile);
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,24 @@ If the old parameter is no longer present (maybe because it has been renamed and
 removed already), no parameters are overwritten. You don't need to remove obsolete
 parameters from the rename map once they have been renamed.
 
+### Skipping file in production mode
+
+You can enable the parameter handler only in development mode (default behavior):
+
+```json
+{
+    "extra": {
+        "incenteev-parameters": {
+            "dev-only": true
+        }
+    }
+}
+
+```
+
+Doing that, calling composer with `---no-dev` flag will disable the parameter
+handler.
+
 ### Managing multiple ignored files
 
 The parameter handler can manage multiple ignored files. To use this feature,

--- a/ScriptHandler.php
+++ b/ScriptHandler.php
@@ -31,7 +31,7 @@ class ScriptHandler
                 throw new \InvalidArgumentException('The extra.incenteev-parameters setting must be an array of configuration objects.');
             }
 
-            $processor->processFile($config);
+            $processor->processFile($config, $event->isDevMode());
         }
     }
 }

--- a/Tests/ProcessorTest.php
+++ b/Tests/ProcessorTest.php
@@ -171,4 +171,34 @@ class ProcessorTest extends ProphecyTestCase
 
         return $tests;
     }
+
+    public function testNoDev()
+    {
+        $dataDir = __DIR__.'/fixtures/dev_only';
+
+        $testCase = array_replace_recursive(
+            array(
+                'title' => 'unknown test',
+                'config' => array(
+                    'file' => 'parameters.yml',
+                ),
+                'dist-file' => 'parameters.yml.dist',
+                'environment' => array(),
+                'interactive' => false,
+            ),
+            (array) Yaml::parse(file_get_contents($dataDir.'/setup.yml'))
+        );
+
+        $workingDir = sys_get_temp_dir() . '/incenteev_parameter_handler';
+        $this->initializeTestCase($testCase, $dataDir, $workingDir);
+
+        $message = sprintf('<info>Skipping the "%s" file</info>', $testCase['config']['file']);
+        $this->io->write($message)->shouldBeCalled();
+
+        $this->setInteractionExpectations($testCase);
+
+        $this->processor->processFile($testCase['config'], false);
+
+        $this->assertFileEquals($dataDir.'/expected.yml', $workingDir.'/'.$testCase['config']['file'], $testCase['title']);
+    }
 }

--- a/Tests/ScriptHandlerTest.php
+++ b/Tests/ScriptHandlerTest.php
@@ -23,6 +23,7 @@ class ScriptHandlerTest extends ProphecyTestCase
         $composer->getPackage()->willReturn($this->package);
         $this->event->getComposer()->willReturn($composer);
         $this->event->getIO()->willReturn($this->io);
+        $this->event->isDevMode()->willReturn(true);
     }
 
     /**

--- a/Tests/fixtures/dev_only/dist.yml
+++ b/Tests/fixtures/dev_only/dist.yml
@@ -1,0 +1,3 @@
+parameters:
+    foo: bar
+    foo2: bar2

--- a/Tests/fixtures/dev_only/existing.yml
+++ b/Tests/fixtures/dev_only/existing.yml
@@ -1,0 +1,3 @@
+# This file is auto-generated during the composer install
+parameters:
+    foo: bar

--- a/Tests/fixtures/dev_only/expected.yml
+++ b/Tests/fixtures/dev_only/expected.yml
@@ -1,0 +1,3 @@
+# This file is auto-generated during the composer install
+parameters:
+    foo: bar

--- a/Tests/fixtures/dev_only/setup.yml
+++ b/Tests/fixtures/dev_only/setup.yml
@@ -1,0 +1,4 @@
+title: Skip file in production mode
+
+config:
+    dev-only: true


### PR DESCRIPTION
When you use the composer post-install scripts to build your app in production, you don't always want your parameters to be handled by the parameter handler.
We have the option to run composer with the `--no-scripts` flag, and create an other script to call after the composer install specifically in production, but it seems less comfortable than just add an option to disable the parameter handler when the `--no-dev` flag is given to composer.