### PR TITLE
Drop the phpspec/prophecy-phpunit package and load PHPUnit via composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
     - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
     - composer update $COMPOSER_FLAGS
 
-script: phpunit --coverage-text --coverage-clover=coverage.clover
+script: ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
     - wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/Tests/ProcessorTest.php
+++ b/Tests/ProcessorTest.php
@@ -3,11 +3,11 @@
 namespace Incenteev\ParameterHandler\Tests;
 
 use Incenteev\ParameterHandler\Processor;
-use Prophecy\PhpUnit\ProphecyTestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 
-class ProcessorTest extends ProphecyTestCase
+class ProcessorTest extends TestCase
 {
     private $io;
     private $environmentBackup = array();

--- a/Tests/ScriptHandlerTest.php
+++ b/Tests/ScriptHandlerTest.php
@@ -3,9 +3,9 @@
 namespace Incenteev\ParameterHandler\Tests;
 
 use Incenteev\ParameterHandler\ScriptHandler;
-use Prophecy\PhpUnit\ProphecyTestCase;
+use PHPUnit\Framework\TestCase;
 
-class ScriptHandlerTest extends ProphecyTestCase
+class ScriptHandlerTest extends TestCase
 {
     private $event;
     private $io;

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "composer/composer": "1.0.*@dev",
-        "phpspec/prophecy-phpunit": "~1.0",
+        "phpunit/phpunit": "^4.8.35 || ^5.6",
         "symfony/filesystem": "~2.2"
     },
     "autoload": {


### PR DESCRIPTION
This PR drops the abandoned `phpspec/prophecy-phpunit` package. It also adds PHPUnit to the dev dependencies which should make sure, composer does not pull dependencies that conflict with the version of PHPUnit we're using.