### PR TITLE
Fix php 5.3 test run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
 matrix:
     include:
         - php: 5.3
+          dist: precise
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
         - php: 5.4
         - php: 5.5


### PR DESCRIPTION
Currently, php 5.3 builds on Travis CI terminate with the following error message:

```
PHP 5.3 is supported only on Precise.
```

This PR should fix that.