### PR TITLE
Drop support for old PHP versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,11 @@ jobs:
     name: Check composer.json
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           coverage: none
-          php-version: '8.0'
+          php-version: '8.3'
       - run: composer validate --strict --no-check-lock
 
   tests:
@@ -26,12 +26,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3' ]
         min_stability: [ '' ]
         name_suffix: [ '' ]
         composer_flags: [ '' ]
         include:
-          - php: '8.0'
+          - php: '8.3'
             min_stability: 'dev'
             name_suffix: ' (dev deps)'
           - php: '7.4'
@@ -40,7 +40,7 @@ jobs:
             composer_flags: '--prefer-lowest --prefer-stable'
 
     steps:
-      -   uses: actions/checkout@v2
+      -   uses: actions/checkout@v4
       -   uses: shivammathur/setup-php@v2
           with:
             coverage: "none"
@@ -53,8 +53,5 @@ jobs:
       -   name: Install dependencies
           run: composer update --ansi --no-progress --prefer-dist --no-interaction ${{ matrix.composer_flags }}
 
-      -   name: Install PHPUnit
-          run: vendor/bin/simple-phpunit install
-
       -   name: Run tests
-          run: vendor/bin/simple-phpunit
+          run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 phpunit.xml
 vendor
 build
+/.phpunit.result.cache

--- a/Tests/ProcessorTest.php
+++ b/Tests/ProcessorTest.php
@@ -2,13 +2,21 @@
 
 namespace Incenteev\ParameterHandler\Tests;
 
+use Composer\IO\IOInterface;
 use Incenteev\ParameterHandler\Processor;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 
 class ProcessorTest extends TestCase
 {
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<IOInterface>
+     */
     private $io;
     private $environmentBackup = array();
 
@@ -17,7 +25,7 @@ class ProcessorTest extends TestCase
      */
     private $processor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -25,7 +33,7 @@ class ProcessorTest extends TestCase
         $this->processor = new Processor($this->io->reveal());
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 
@@ -45,12 +53,8 @@ class ProcessorTest extends TestCase
     {
         chdir(__DIR__);
 
-        if (method_exists($this, 'expectException')) {
-            $this->expectException('InvalidArgumentException');
-            $this->expectExceptionMessage($exceptionMessage);
-        } else {
-            $this->setExpectedException('InvalidArgumentException', $exceptionMessage);
-        }
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage($exceptionMessage);
 
         $this->processor->processFile($config);
     }

--- a/Tests/ScriptHandlerTest.php
+++ b/Tests/ScriptHandlerTest.php
@@ -2,22 +2,38 @@
 
 namespace Incenteev\ParameterHandler\Tests;
 
+use Composer\IO\IOInterface;
+use Composer\Package\RootPackageInterface;
+use Composer\Script\Event;
 use Incenteev\ParameterHandler\ScriptHandler;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 
 class ScriptHandlerTest extends TestCase
 {
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<Event>
+     */
     private $event;
+    /**
+     * @var ObjectProphecy<IOInterface>
+     */
     private $io;
+    /**
+     * @var ObjectProphecy<RootPackageInterface>
+     */
     private $package;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->event = $this->prophesize('Composer\Script\Event');
         $this->io = $this->prophesize('Composer\IO\IOInterface');
-        $this->package = $this->prophesize('Composer\Package\PackageInterface');
+        $this->package = $this->prophesize(RootPackageInterface::class);
         $composer = $this->prophesize('Composer\Composer');
 
         $composer->getPackage()->willReturn($this->package);
@@ -34,12 +50,8 @@ class ScriptHandlerTest extends TestCase
 
         chdir(__DIR__);
 
-        if (method_exists($this, 'expectException')) {
-            $this->expectException('InvalidArgumentException');
-            $this->expectExceptionMessage($exceptionMessage);
-        } else {
-            $this->setExpectedException('InvalidArgumentException', $exceptionMessage);
-        }
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage($exceptionMessage);
 
         ScriptHandler::buildParameters($this->event->reveal());
     }

--- a/composer.json
+++ b/composer.json
@@ -11,20 +11,25 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
-        "symfony/yaml": "^2.3 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
+        "php": ">=7.4",
+        "symfony/yaml": "^5.4 || ^6.0"
     },
     "require-dev": {
-        "composer/composer": "^1.0@dev",
-        "symfony/filesystem": "^2.3 || ^3 || ^4 || ^5 || ^6.0",
-        "symfony/phpunit-bridge": "^3.4.47 || ^4.4.41 || ^5.4.8 || ^6.0"
+        "composer/composer": "^2.0@dev",
+        "phpspec/prophecy-phpunit": "^2.1",
+        "phpunit/phpunit": "^9.6",
+        "symfony/filesystem": "^5.4 || ^6.0",
+        "symfony/phpunit-bridge": "^6.4.1 || ^7.0.1"
     },
     "autoload": {
         "psr-4": { "Incenteev\\ParameterHandler\\": "" }
     },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.1.x-dev"
+            "dev-master": "2.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="Incenteev ParameterHandler Test Suite">
             <directory suffix="Test.php">./Tests/</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory>.</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
This makes it a lot easier to manage the testsuite when we don't need to keep support for old PHPUnit version to support PHP 5.3.